### PR TITLE
Add LibGit2Sharp-based Git services and DI registration

### DIFF
--- a/src/Apps/PublicTxt.CLI/PublicTxt.CLI.csproj
+++ b/src/Apps/PublicTxt.CLI/PublicTxt.CLI.csproj
@@ -1,10 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\PublicTxt.Core\PublicTxt.Core.csproj" />
+    <ProjectReference Include="..\..\Infrastructure\PublicTxt.Git\PublicTxt.Git.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Core/PublicTxt.Core/Class1.cs
+++ b/src/Core/PublicTxt.Core/Class1.cs
@@ -1,5 +1,0 @@
-﻿namespace PublicTxt.Core;
-
-public class Class1
-{
-}

--- a/src/Core/PublicTxt.Core/Git/GitCloneOptions.cs
+++ b/src/Core/PublicTxt.Core/Git/GitCloneOptions.cs
@@ -1,0 +1,10 @@
+namespace PublicTxt.Core.Git;
+
+public sealed class GitCloneOptions
+{
+    public bool Checkout { get; init; } = true;
+
+    public string? BranchName { get; init; }
+
+    public GitCredentials? Credentials { get; init; }
+}

--- a/src/Core/PublicTxt.Core/Git/GitCredentials.cs
+++ b/src/Core/PublicTxt.Core/Git/GitCredentials.cs
@@ -1,0 +1,8 @@
+namespace PublicTxt.Core.Git;
+
+public sealed class GitCredentials
+{
+    public required string Username { get; init; }
+
+    public required string Password { get; init; }
+}

--- a/src/Core/PublicTxt.Core/Git/IGitRepositoryService.cs
+++ b/src/Core/PublicTxt.Core/Git/IGitRepositoryService.cs
@@ -1,0 +1,12 @@
+namespace PublicTxt.Core.Git;
+
+public interface IGitRepositoryService
+{
+    Task<bool> RepositoryExistsAsync(string path, CancellationToken cancellationToken = default);
+
+    Task CloneAsync(string sourceUrl, string workdirPath, GitCloneOptions? options = null, CancellationToken cancellationToken = default);
+
+    Task<string?> GetCurrentBranchAsync(string path, CancellationToken cancellationToken = default);
+
+    Task FetchAsync(string path, string remoteName = "origin", CancellationToken cancellationToken = default);
+}

--- a/src/Infrastructure/PublicTxt.Git/Class1.cs
+++ b/src/Infrastructure/PublicTxt.Git/Class1.cs
@@ -1,5 +1,0 @@
-﻿namespace PublicTxt.Git;
-
-public class Class1
-{
-}

--- a/src/Infrastructure/PublicTxt.Git/LibGit2SharpRepositoryService.cs
+++ b/src/Infrastructure/PublicTxt.Git/LibGit2SharpRepositoryService.cs
@@ -1,0 +1,83 @@
+using LibGit2Sharp;
+using PublicTxt.Core.Git;
+
+namespace PublicTxt.Git;
+
+public sealed class LibGit2SharpRepositoryService : IGitRepositoryService
+{
+    public Task<bool> RepositoryExistsAsync(string path, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        return Task.FromResult(Repository.IsValid(path));
+    }
+
+    public Task CloneAsync(string sourceUrl, string workdirPath, GitCloneOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sourceUrl);
+        ArgumentException.ThrowIfNullOrEmpty(workdirPath);
+
+        return Task.Run(() =>
+        {
+            var cloneOptions = BuildCloneOptions(options);
+            Repository.Clone(sourceUrl, workdirPath, cloneOptions);
+        }, cancellationToken);
+    }
+
+    public Task<string?> GetCurrentBranchAsync(string path, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        return Task.Run(() =>
+        {
+            using var repository = new Repository(path);
+            return repository.Head?.FriendlyName;
+        }, cancellationToken);
+    }
+
+    public Task FetchAsync(string path, string remoteName = "origin", CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentException.ThrowIfNullOrEmpty(remoteName);
+
+        return Task.Run(() =>
+        {
+            using var repository = new Repository(path);
+            var remote = repository.Network.Remotes[remoteName] ?? throw new InvalidOperationException($"Remote '{remoteName}' not found.");
+
+            var fetchOptions = new FetchOptions();
+            if (repository.Network.Remotes.Any() && remote.FetchRefSpecs.Any())
+            {
+                Commands.Fetch(repository, remote.Name, remote.FetchRefSpecs.Select(s => s.Specification), fetchOptions, null);
+            }
+            else
+            {
+                Commands.Fetch(repository, remote.Name, Array.Empty<string>(), fetchOptions, null);
+            }
+        }, cancellationToken);
+    }
+
+    private static CloneOptions BuildCloneOptions(GitCloneOptions? options)
+    {
+        var cloneOptions = new CloneOptions
+        {
+            Checkout = options?.Checkout ?? true
+        };
+
+        if (!string.IsNullOrWhiteSpace(options?.BranchName))
+        {
+            cloneOptions.BranchName = options!.BranchName;
+        }
+
+        if (options?.Credentials is not null)
+        {
+            cloneOptions.CredentialsProvider = (_, _, _) => new UsernamePasswordCredentials
+            {
+                Username = options.Credentials.Username,
+                Password = options.Credentials.Password
+            };
+        }
+
+        return cloneOptions;
+    }
+}

--- a/src/Infrastructure/PublicTxt.Git/PublicTxt.Git.csproj
+++ b/src/Infrastructure/PublicTxt.Git/PublicTxt.Git.csproj
@@ -1,9 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\PublicTxt.Core\PublicTxt.Core.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Infrastructure/PublicTxt.Git/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/PublicTxt.Git/ServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+using PublicTxt.Core.Git;
+
+namespace PublicTxt.Git;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddGitInfrastructure(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<IGitRepositoryService, LibGit2SharpRepositoryService>();
+
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary
- add core abstractions that describe the Git repository services PublicTxt needs
- implement a LibGit2Sharp-backed repository service and expose a DI registration entry point
- wire the CLI and infrastructure projects together and bring in the required package dependencies

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_690c456576108328af061803bd1ea37d